### PR TITLE
upgrade ClusterRoleBinding version

### DIFF
--- a/docs/user-manuals/iot/edgex-foundry.md
+++ b/docs/user-manuals/iot/edgex-foundry.md
@@ -216,7 +216,7 @@ spec:
   revisionHistoryLimit: 5
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: default-cluster-admin
 subjects:


### PR DESCRIPTION

Warning: rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding