### PR TITLE
path to yurtadm executable is incorrect, should be default.

### DIFF
--- a/docs/installation/yurtadm-init-join.md
+++ b/docs/installation/yurtadm-init-join.md
@@ -10,7 +10,7 @@ To expand the cluster later, users can use the Yurtadm join command to add edge 
 
 ## 2.Process
 
-### 2.1Compile Yurtadm
+### 2.1 Compile Yurtadm
 When initializing the cluster, you need to obtain the Yurtadm executable first. To quickly build and install yurtadm, you can execute the following command to complete the installation if the build system has golang 1.13+ and bash installed:
 
 ```sh
@@ -19,14 +19,14 @@ $ cd openyurt
 $ make build WHAT="yurtadm" ARCH="amd64" REGION=cn
 ```
 
-The executable will be stored in the `_output/bin/` directory.
+The executable will be stored in the `_output/local/bin/` directory, depends on the platform.
 
 ### 2.2 Initialize the cluster
 
 Execute the following command to initialize the cluster:
 
 ```sh
-$ _output/bin/yurtadm init --apiserver-advertise-address 1.2.3.4 --openyurt-version latest --passwd 1234
+$ _output/local/bin/linux/amd64/yurtadm init --apiserver-advertise-address 1.2.3.4 --openyurt-version latest --passwd 1234
 ```
 
 The main parameters are:
@@ -46,18 +46,18 @@ Users can join cloud nodes and edge nodes to the OpenYurt cluster using Yurtadm 
 Execute the following command to join the edge node to cluster:
 
 ```sh
-$ _output/bin/yurtadm join 1.2.3.4:6443 --token=zffaj3.a5vjzf09qn9ft3gt --node-type=edge --discovery-token-unsafe-skip-ca-verification --v=5
+$ _output/local/bin/linux/amd64/yurtadm join 1.2.3.4:6443 --token=zffaj3.a5vjzf09qn9ft3gt --node-type=edge --discovery-token-unsafe-skip-ca-verification --v=5
 ```
 
 Execute the following command to join the cloud node to cluster:
 
 ```sh
-$ _output/bin/yurtadm join 1.2.3.4:6443 --token=zffaj3.a5vjzf09qn9ft3gt --node-type=cloud --discovery-token-unsafe-skip-ca-verification --v=5
+$ _output/local/bin/linux/amd64/yurtadm join 1.2.3.4:6443 --token=zffaj3.a5vjzf09qn9ft3gt --node-type=cloud --discovery-token-unsafe-skip-ca-verification --v=5
 ```
 
 When the runtime of the edge node is containerd, the `cri-socket` parameter needs to be configured. For example, change the command above of joining the edge node to:
 ```sh
-$ _output/bin/yurtadm join 1.2.3.4:6443 --token=zffaj3.a5vjzf09qn9ft3gt --node-type=edge --discovery-token-unsafe-skip-ca-verification --cri-socket=/run/containerd/containerd.sock --v=5
+$ _output/local/bin/linux/amd64/yurtadm join 1.2.3.4:6443 --token=zffaj3.a5vjzf09qn9ft3gt --node-type=edge --discovery-token-unsafe-skip-ca-verification --cri-socket=/run/containerd/containerd.sock --v=5
 ```
 
 

--- a/i18n/zh/docusaurus-plugin-content-docs/current/installation/yurtadm-init-join.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/installation/yurtadm-init-join.md
@@ -20,14 +20,14 @@ $ cd openyurt
 $ make build WHAT="yurtadm" ARCH="amd64" REGION=cn
 ```
 
-可执行文件将存放在 `_output/bin/` 目录下。
+可执行文件将存放在 `_output/local/bin/` 目录下。
 
 ### 2.2初始化集群
 
 执行以下命令初始化集群：
 
 ```sh
-$ _output/bin/yurtadm init --apiserver-advertise-address 1.2.3.4 --openyurt-version latest --passwd 1234
+$ _output/local/bin/linux/amd64/yurtadm init --apiserver-advertise-address 1.2.3.4 --openyurt-version latest --passwd 1234
 ```
 
 其中主要参数为：
@@ -47,17 +47,17 @@ $ _output/bin/yurtadm init --apiserver-advertise-address 1.2.3.4 --openyurt-vers
 执行以下命令加入边缘节点：
 
 ```sh
-$ _output/bin/yurtadm join 1.2.3.4:6443 --token=zffaj3.a5vjzf09qn9ft3gt --node-type=edge --discovery-token-unsafe-skip-ca-verification --v=5
+$ _output/local/bin/linux/amd64/yurtadm join 1.2.3.4:6443 --token=zffaj3.a5vjzf09qn9ft3gt --node-type=edge --discovery-token-unsafe-skip-ca-verification --v=5
 ```
 
 执行以下命令加入云端节点：
 
 ```sh
-$ _output/bin/yurtadm join 1.2.3.4:6443 --token=zffaj3.a5vjzf09qn9ft3gt --node-type=cloud --discovery-token-unsafe-skip-ca-verification --v=5
+$ _output/local/bin/linux/amd64/yurtadm join 1.2.3.4:6443 --token=zffaj3.a5vjzf09qn9ft3gt --node-type=cloud --discovery-token-unsafe-skip-ca-verification --v=5
 ```
 当边缘节点runtime为containerd时，需要配置`cri-socket`参数，如上面执行命令加入边缘节点改为：
 ```sh
-$ _output/bin/yurtadm join 1.2.3.4:6443 --token=zffaj3.a5vjzf09qn9ft3gt --node-type=edge --discovery-token-unsafe-skip-ca-verification --cri-socket=/run/containerd/containerd.sock --v=5
+$ _output/local/bin/linux/amd64/yurtadm join 1.2.3.4:6443 --token=zffaj3.a5vjzf09qn9ft3gt --node-type=edge --discovery-token-unsafe-skip-ca-verification --cri-socket=/run/containerd/containerd.sock --v=5
 ```
 
 ## 3.实现细节

--- a/i18n/zh/docusaurus-plugin-content-docs/version-v0.7.0/installation/yurtadm-init-join.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/version-v0.7.0/installation/yurtadm-init-join.md
@@ -20,14 +20,14 @@ $ cd openyurt
 $ make build WHAT="yurtadm" ARCH="amd64" REGION=cn
 ```
 
-可执行文件将存放在 `_output/bin/` 目录下。
+可执行文件将存放在 `_output/local/bin/` 目录下。
 
 ### 2.2初始化集群
 
 执行以下命令初始化集群：
 
 ```sh
-$ _output/bin/yurtadm init --apiserver-advertise-address 1.2.3.4 --openyurt-version latest --passwd 1234
+$ _output/local/bin/linux/amd64/yurtadm init --apiserver-advertise-address 1.2.3.4 --openyurt-version latest --passwd 1234
 ```
 
 其中主要参数为：
@@ -47,17 +47,17 @@ $ _output/bin/yurtadm init --apiserver-advertise-address 1.2.3.4 --openyurt-vers
 执行以下命令加入边缘节点：
 
 ```sh
-$ _output/bin/yurtadm join 1.2.3.4:6443 --token=zffaj3.a5vjzf09qn9ft3gt --node-type=edge --discovery-token-unsafe-skip-ca-verification --v=5
+$ _output/local/bin/linux/amd64/yurtadm join 1.2.3.4:6443 --token=zffaj3.a5vjzf09qn9ft3gt --node-type=edge --discovery-token-unsafe-skip-ca-verification --v=5
 ```
 
 执行以下命令加入云端节点：
 
 ```sh
-$ _output/bin/yurtadm join 1.2.3.4:6443 --token=zffaj3.a5vjzf09qn9ft3gt --node-type=cloud --discovery-token-unsafe-skip-ca-verification --v=5
+$ _output/local/bin/linux/amd64/yurtadm join 1.2.3.4:6443 --token=zffaj3.a5vjzf09qn9ft3gt --node-type=cloud --discovery-token-unsafe-skip-ca-verification --v=5
 ```
 当边缘节点runtime为containerd时，需要配置`cri-socket`参数，如上面执行命令加入边缘节点改为：
 ```sh
-$ _output/bin/yurtadm join 1.2.3.4:6443 --token=zffaj3.a5vjzf09qn9ft3gt --node-type=edge --discovery-token-unsafe-skip-ca-verification --cri-socket=/run/containerd/containerd.sock --v=5
+$ _output/local/bin/linux/amd64/yurtadm join 1.2.3.4:6443 --token=zffaj3.a5vjzf09qn9ft3gt --node-type=edge --discovery-token-unsafe-skip-ca-verification --cri-socket=/run/containerd/containerd.sock --v=5
 ```
 
 ## 3.实现细节

--- a/versioned_docs/version-v0.7.0/installation/yurtadm-init-join.md
+++ b/versioned_docs/version-v0.7.0/installation/yurtadm-init-join.md
@@ -10,7 +10,7 @@ To expand the cluster later, users can use the Yurtadm join command to add edge 
 
 ## 2.Process
 
-### 2.1Compile Yurtadm
+### 2.1 Compile Yurtadm
 When initializing the cluster, you need to obtain the Yurtadm executable first. To quickly build and install yurtadm, you can execute the following command to complete the installation if the build system has golang 1.13+ and bash installed:
 
 ```sh
@@ -19,14 +19,14 @@ $ cd openyurt
 $ make build WHAT="yurtadm" ARCH="amd64" REGION=cn
 ```
 
-The executable will be stored in the `_output/bin/` directory.
+The executable will be stored in the `_output/local/bin/` directory, depends on the platform.
 
 ### 2.2 Initialize the cluster
 
 Execute the following command to initialize the cluster:
 
 ```sh
-$ _output/bin/yurtadm init --apiserver-advertise-address 1.2.3.4 --openyurt-version latest --passwd 1234
+$ _output/local/bin/linux/amd64/yurtadm init --apiserver-advertise-address 1.2.3.4 --openyurt-version latest --passwd 1234
 ```
 
 The main parameters are:
@@ -46,18 +46,18 @@ Users can join cloud nodes and edge nodes to the OpenYurt cluster using Yurtadm 
 Execute the following command to join the edge node to cluster:
 
 ```sh
-$ _output/bin/yurtadm join 1.2.3.4:6443 --token=zffaj3.a5vjzf09qn9ft3gt --node-type=edge --discovery-token-unsafe-skip-ca-verification --v=5
+$ _output/local/bin/linux/amd64/yurtadm join 1.2.3.4:6443 --token=zffaj3.a5vjzf09qn9ft3gt --node-type=edge --discovery-token-unsafe-skip-ca-verification --v=5
 ```
 
 Execute the following command to join the cloud node to cluster:
 
 ```sh
-$ _output/bin/yurtadm join 1.2.3.4:6443 --token=zffaj3.a5vjzf09qn9ft3gt --node-type=cloud --discovery-token-unsafe-skip-ca-verification --v=5
+$ _output/local/bin/linux/amd64/yurtadm join 1.2.3.4:6443 --token=zffaj3.a5vjzf09qn9ft3gt --node-type=cloud --discovery-token-unsafe-skip-ca-verification --v=5
 ```
 
 When the runtime of the edge node is containerd, the `cri-socket` parameter needs to be configured. For example, change the command above of joining the edge node to:
 ```sh
-$ _output/bin/yurtadm join 1.2.3.4:6443 --token=zffaj3.a5vjzf09qn9ft3gt --node-type=edge --discovery-token-unsafe-skip-ca-verification --cri-socket=/run/containerd/containerd.sock --v=5
+$ _output/local/bin/linux/amd64/yurtadm join 1.2.3.4:6443 --token=zffaj3.a5vjzf09qn9ft3gt --node-type=edge --discovery-token-unsafe-skip-ca-verification --cri-socket=/run/containerd/containerd.sock --v=5
 ```
 
 


### PR DESCRIPTION
minor doc fix.

according to the following, path is not correct, and i guess default path should be displayed in doc with annotation.

https://github.com/openyurtio/openyurt/blob/27514fc7c7a652d0c7f457dac689b208456cd1cb/hack/lib/init.sh#L24

I am not sure other executables whether it uses `YURT_BIN_DIR` or `YURT_LOCAL_BIN_DIR`, but yurtadm is built like below.

```bash
tomoyafujita@~/DVT/03_OSS/github.com/openyurtio/openyurt >cat /etc/lsb-release 
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=20.04
DISTRIB_CODENAME=focal
DISTRIB_DESCRIPTION="Ubuntu 20.04.4 LTS"

tomoyafujita@~/DVT/03_OSS/github.com/openyurtio/openyurt >make build WHAT="yurtadm" ARCH="amd64" REGION=us
bash hack/make-rules/build.sh yurtadm
+++ dirname hack/make-rules/build.sh
...<snip>

tomoyafujita@~/DVT/03_OSS/github.com/openyurtio/openyurt >find _output/
_output/
_output/local
_output/local/bin
_output/local/bin/linux
_output/local/bin/linux/amd64
_output/local/bin/linux/amd64/yurtadm
```

Signed-off-by: Tomoya Fujita <Tomoya.Fujita@sony.com>