### PR TITLE
fix: update local builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine AS BUILD_IMAGE
+FROM node:20-alpine AS BUILD_IMAGE
 
 # Create app directory
 WORKDIR /usr/src/app


### PR DESCRIPTION
Make local-start failing. The issue below is node needs to be >=18.0. I've updated the image to match CI `20-alpine`.

```bash
➜  openyurt.io git:(master) ✗ docker run -it -v $(pwd):/app node:16-alpine sh
/app # yarn install --frozen-lockfile
yarn install v1.22.19
[1/4] Resolving packages...
[2/4] Fetching packages...
warning Pattern ["react-helmet-async@npm:@slorber/react-helmet-async@*"] is trying to unpack in the same destination "/usr/local/share/.cache/yarn/v6/npm-react-helmet-async-1.3.0-11fbc6094605cf60aa04a28c17e0aab894b4ecff-integrity/node_modules/react-helmet-async" as pattern ["react-helmet-async@npm:@slorber/react-helmet-async@1.3.0"]. This could result in non-deterministic behavior, skipping.
error @docusaurus/core@3.7.0: The engine "node" is incompatible with this module. Expected version ">=18.0". Got "16.20.2"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```