### PR TITLE
docs: add guide for label-driven edge node conversion

### DIFF
--- a/docs/user-manuals/node-management/convert-a-node-to-edge.md
+++ b/docs/user-manuals/node-management/convert-a-node-to-edge.md
@@ -1,0 +1,70 @@
+---
+title: Convert a worker node to an edge node
+---
+
+Starting with OpenYurt v1.7.0, an existing Kubernetes worker node can be converted into an edge node by adding it to an `Edge` node pool. The `yurt-node-conversion-controller` in `yurt-manager` watches the node pool label and runs a `node-servant` Job that installs YurtHub on the node, so `yurtadm` is not required for this flow.
+
+## Prerequisites
+
+- `yurt-manager` v1.7.0 or later is installed. The `yurt-node-conversion-controller` ships with it.
+- An `Edge` node pool exists. See [Create a node pool](../node-pool-management/create-a-node-pool.md).
+- The target node is a worker already registered in the cluster.
+
+## Convert a node
+
+Label the node with the target `Edge` pool. This is the only label you set on the node; the controller manages the rest.
+
+```shell
+$ kubectl label node <node> apps.openyurt.io/nodepool=<edge-pool>
+```
+
+> The pool must be `type: Edge`. Labeling a node into a `Cloud` pool associates it with the pool but does not start a conversion.
+
+> Do not set `openyurt.io/is-edge-worker` manually. The controller writes that label once the conversion succeeds. Setting it by hand can make the controller skip the conversion or start a revert.
+
+After the label is added, the controller:
+
+1. Cordons the node (`spec.unschedulable: true`) for the duration of the conversion.
+2. Creates a Job named `node-servant-conversion-<node>` in the `kube-system` namespace (`backoffLimit: 3`) that installs YurtHub on the host.
+3. On success, sets `openyurt.io/is-edge-worker=true`, uncordons the node, and records the outcome in the `YurtNodeConversionFailed` node condition.
+
+## Verify the conversion
+
+The result is reported through the `YurtNodeConversionFailed` node condition:
+
+| State | `status` | `reason` |
+| --- | --- | --- |
+| In progress | `False` | `Converting` |
+| Success | `False` | `Converted` |
+| Failure | `True` | `ConvertFailed` |
+
+Check the condition:
+
+```shell
+$ kubectl get node <node> -o jsonpath='{range .status.conditions[?(@.type=="YurtNodeConversionFailed")]}{.status}{" "}{.reason}{"\n"}{end}'
+False Converted
+```
+
+A converted node also carries the `is-edge-worker` label and is schedulable again:
+
+```shell
+$ kubectl get node <node> -o jsonpath='{.metadata.labels.openyurt\.io/is-edge-worker}{"\n"}'
+true
+```
+
+## Troubleshoot a failed conversion
+
+If the Job fails, the controller keeps the node cordoned and sets `YurtNodeConversionFailed` to `status: "True"`, `reason: ConvertFailed`. The failure message is copied from the Job.
+
+Inspect the Job and its logs:
+
+```shell
+$ kubectl get job node-servant-conversion-<node> -n kube-system
+$ kubectl logs job/node-servant-conversion-<node> -n kube-system
+```
+
+Finished Jobs are kept for two hours (`ttlSecondsAfterFinished: 7200`) so the logs stay available. After fixing the underlying cause, delete the failed Job. The label is still present, so the controller starts a new conversion round:
+
+```shell
+$ kubectl delete job node-servant-conversion-<node> -n kube-system
+```

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/node-management/convert-a-node-to-edge.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/node-management/convert-a-node-to-edge.md
@@ -1,0 +1,70 @@
+---
+title: 将工作节点转换为边缘节点
+---
+
+从 OpenYurt v1.7.0 开始，可以通过把一个已有的 Kubernetes 工作节点加入到 `Edge` 类型的节点池，将其转换为边缘节点。`yurt-manager` 中的 `yurt-node-conversion-controller` 会监听节点池标签，并运行一个 `node-servant` Job 在节点上安装 YurtHub，因此该流程不需要使用 `yurtadm`。
+
+## 前置条件
+
+- 已安装 `yurt-manager` v1.7.0 或更高版本，`yurt-node-conversion-controller` 随其一起提供。
+- 已存在一个 `Edge` 类型的节点池。参见[创建节点池](../node-pool-management/create-a-node-pool.md)。
+- 目标节点是集群中已注册的工作节点。
+
+## 转换节点
+
+给节点打上目标 `Edge` 节点池的标签。你只需在节点上设置这一个标签，其余由控制器管理。
+
+```shell
+$ kubectl label node <node> apps.openyurt.io/nodepool=<edge-pool>
+```
+
+> 节点池必须是 `type: Edge`。将节点加入 `Cloud` 节点池只会建立关联，并不会触发转换。
+
+> 不要手动设置 `openyurt.io/is-edge-worker`。该标签由控制器在转换成功后写入，手动设置可能导致控制器跳过转换或触发回退（revert）。
+
+标签添加后，控制器会：
+
+1. 在转换期间将节点标记为不可调度（`spec.unschedulable: true`）。
+2. 在 `kube-system` 命名空间创建名为 `node-servant-conversion-<node>` 的 Job（`backoffLimit: 3`），由它在节点上安装 YurtHub。
+3. 转换成功后设置 `openyurt.io/is-edge-worker=true`，恢复节点可调度，并将结果记录到 `YurtNodeConversionFailed` 节点状态条件中。
+
+## 验证转换结果
+
+转换结果通过 `YurtNodeConversionFailed` 节点状态条件反馈：
+
+| 状态 | `status` | `reason` |
+| --- | --- | --- |
+| 进行中 | `False` | `Converting` |
+| 成功 | `False` | `Converted` |
+| 失败 | `True` | `ConvertFailed` |
+
+查看该条件：
+
+```shell
+$ kubectl get node <node> -o jsonpath='{range .status.conditions[?(@.type=="YurtNodeConversionFailed")]}{.status}{" "}{.reason}{"\n"}{end}'
+False Converted
+```
+
+转换完成的节点还会带有 `is-edge-worker` 标签，并恢复为可调度状态：
+
+```shell
+$ kubectl get node <node> -o jsonpath='{.metadata.labels.openyurt\.io/is-edge-worker}{"\n"}'
+true
+```
+
+## 排查失败的转换
+
+如果 Job 失败，控制器会保持节点不可调度，并把 `YurtNodeConversionFailed` 设为 `status: "True"`、`reason: ConvertFailed`，失败信息会从 Job 中复制过来。
+
+查看 Job 及其日志：
+
+```shell
+$ kubectl get job node-servant-conversion-<node> -n kube-system
+$ kubectl logs job/node-servant-conversion-<node> -n kube-system
+```
+
+已结束的 Job 会保留两小时（`ttlSecondsAfterFinished: 7200`），以便查看日志。定位并修复根因后，删除失败的 Job。由于标签仍然存在，控制器会重新发起一轮转换：
+
+```shell
+$ kubectl delete job node-servant-conversion-<node> -n kube-system
+```

--- a/sidebars.js
+++ b/sidebars.js
@@ -61,6 +61,7 @@ module.exports = {
                     'Node management': [
                         'user-manuals/node-management/node-management-overview',
                         'user-manuals/node-management/join-a-node',
+                        'user-manuals/node-management/convert-a-node-to-edge',
                         'user-manuals/node-management/remove-a-node',
                         'user-manuals/node-management/configure-node-autonomy'
                     ]


### PR DESCRIPTION
### What

Adds a user guide for converting an existing Kubernetes worker into an edge node by labeling it into an `Edge` nodepool. Adds the English page under `user-manuals/node-management/`, the matching zh translation, and a sidebar entry.

### Why

The label-driven conversion added by the `yurt-node-conversion-controller` (openyurtio/openyurt#2533, shipped in v1.7.0) is not documented on the site. The existing node pool docs still describe the older model where the label only associates an already joined node. This page documents the actual v1.7.0 behavior: the `node-servant-conversion-<node>` Job, the cordon lifecycle, and the `YurtNodeConversionFailed` node condition used for verification and troubleshooting.

The gap was also raised in openyurtio/openyurt#2559.

### Testing

`yarn install --frozen-lockfile` and `yarn build` both pass, en and zh locales generated with no broken-link errors.