### PR TITLE
docs: note that the Edge nodepool label triggers conversion

### DIFF
--- a/docs/user-manuals/node-pool-management/node-pool-management.md
+++ b/docs/user-manuals/node-pool-management/node-pool-management.md
@@ -78,6 +78,8 @@ $ kubectl label node k8s-node2 apps.openyurt.io/nodepool=hangzhou
 k8s-node2 labeled
 ```
 
+> For an `Edge` node pool on OpenYurt v1.7.0 and later, adding this label to an existing worker does more than associate it with the pool: the `yurt-node-conversion-controller` converts the node into an edge node and installs YurtHub. See [Convert a worker node to an edge node](../node-management/convert-a-node-to-edge.md).
+
 - Verify whether a node is added to a nodepool:
 
 When an edge node is added to a nodepool, all the annotations/labels of the nodepool are added to the node, together with a new label: `nodepool.openyurt.io/hostnetwork`

--- a/i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/node-pool-management/node-pool-management.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/user-manuals/node-pool-management/node-pool-management.md
@@ -77,6 +77,8 @@ $ kubectl label node k8s-node2 apps.openyurt.io/nodepool=hangzhou
 k8s-node2 labeled
 ```
 
+> 对于 OpenYurt v1.7.0 及以上版本的 `Edge` 节点池，给已有工作节点打上该标签不只是建立关联：`yurt-node-conversion-controller` 会把该节点转换为边缘节点并安装 YurtHub。参见[将工作节点转换为边缘节点](../node-management/convert-a-node-to-edge.md)。
+
 - 验证节点已经加入节点池
 
 当Edge node成功加入到节点池，节点的配置信息除了节点池Spec中的所有内容，同时，节点添加了一个新的标签：`nodepool.openyurt.io/hostnetwork`。


### PR DESCRIPTION
### What

Adds a short note to the node pool management guide (en and zh) that, for `Edge` pools on OpenYurt v1.7.0 and later, labeling an existing worker with `apps.openyurt.io/nodepool` triggers a conversion, not just an association, and links to the conversion guide.

### Why

The current guide describes the label as only associating a node with a pool. Since v1.7.0 the `yurt-node-conversion-controller` (openyurtio/openyurt#2533) converts the node and installs YurtHub when the label is added to an Edge pool. The note points readers to the full guide so the behavior is not surprising.

### Depends on

Companion to #647, which adds the linked page. This PR's build turns green once #647 is merged (CI builds the merge with base).

### Testing

`yarn build` passes with both PRs applied, en and zh locales generated with no broken-link errors.