### PR TITLE
docs: add crictl prerequisite for label-driven node conversion

### DIFF
--- a/docs/installation/yurtadm-join.md
+++ b/docs/installation/yurtadm-join.md
@@ -80,6 +80,12 @@ rm -rf /etc/cni/net.d
 
 The following operations are intended only for existing worker nodes that are already part of a Kubernetes cluster (Node deployment via kubeadm and usage of `systemd` are highly recommended). OpenYurt provides a declarative **Label-Driven YurtHub mechanism** to automatically convert a standard node into an edge node.
 
+### Prerequisites for Node Conversion
+
+Before converting a node, ensure the following tools are installed on the target edge nodes:
+- `crictl` (from `cri-tools`): The node conversion process utilizes a privileged `node-servant` Job that executes `crictl` directly on the host to manage container lifecycles during the transition. If `crictl` is missing, the conversion Job will fail.
+
+
 ### 2.1 convert
 
 Suppose we want to integrate an existing Kubernetes node into a NodePool to manage units and enable edge autonomy.


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation

#### What this PR does / why we need it:
While mapping out the new label-driven node conversion flow, I saw @Jonny-ee mention in issue openyurtio/openyurt#2559 that `crictl` is a hard dependency for `node-servant` that currently isn't documented. 

If you try to convert an edge node using the `apps.openyurt.io/nodepool` label on a standard `kubeadm` setup, the `node-servant` Job silently crashes if `crictl` isn't installed, because (as seen in `pkg/node-servant/components/runtime.go`) it actively uses it to stop components like `kube-proxy` directly on the host. 

I made this quick update to the docs to address that gap before it trips anyone else up.

It covers:
- Adding `crictl` to the prerequisite list for the `convert` process
- Explaining exactly why `node-servant` needs it to manage container lifecycles

#### Which issue(s) this PR fixes:
Fixes the documentation gap explicitly called out in openyurtio/openyurt#2559

#### Special notes for your reviewer:
(Side note: I noticed the Chinese translation in `i18n/zh/.../yurtadm-join.md` might need a parallel update. I didn't touch it to keep this PR clean, but happy to push a commit for that too if the team prefers!)

Let me know if this looks good to merge.

#### Does this PR introduce a user-facing change?
```release-note
crictl is now explicitly listed as a prerequisite for edge node conversion.
